### PR TITLE
add Codex conversation export

### DIFF
--- a/EXPORT_CONVERSATION_CODEX_OUTIL.md
+++ b/EXPORT_CONVERSATION_CODEX_OUTIL.md
@@ -1,0 +1,322 @@
+# Export conversation Codex - Outil Easy Codec
+
+Ce fichier contient un export lisible des echanges avec Codex autour de l'outil Easy Codec.
+
+Note: il reprend les messages visibles de cette conversation. Les sorties techniques longues des commandes ne sont pas toutes recopiees integralement; les actions importantes et les resultats utiles sont conserves.
+
+## Echange 1 - Clarifier le mode d'emploi principal
+
+### Utilisateur
+
+> essaie de rendre ca un peu plus claire encore et simple a suivre enfin comme le read me de public un peu je pense que ce serait bien
+
+### Codex
+
+> Je vais d'abord lire le mode d'emploi et le README public pour caler le ton et la structure, puis je retouche le fichier en gardant l'objectif "plus clair, plus simple a suivre".
+
+Actions faites:
+
+- lecture de `MODE_EMPLOI_OUTIL_PRINCIPAL.md`;
+- lecture de `README.md`;
+- lecture de `MODE_EMPLOI_ROM_CONFIG_FINDER.md`;
+- reecriture de `MODE_EMPLOI_OUTIL_PRINCIPAL.md`.
+
+### Codex
+
+> J'ai le document actuel et la liste des fichiers. Je lis maintenant le README pour reprendre sa logique plus "guide simple", puis je reorganise le mode d'emploi autour du chemin le plus courant.
+
+### Codex
+
+> Le README est plus direct: role, lancement, workflow, puis integration. Je vais aligner le mode d'emploi sur cette lecture, avec moins de tables quand une liste suffit et un ordre plus "je fais quoi maintenant ?".
+
+### Codex
+
+> La reecriture est en place. Je fais une derniere lecture et un diff rapide pour reperer les petites lourdeurs ou une erreur de formulation avant de te rendre ca.
+
+### Codex - reponse finale
+
+J'ai simplifie `MODE_EMPLOI_OUTIL_PRINCIPAL.md` en le rapprochant du style du `README.md` public.
+
+Principaux changements:
+
+- structure plus directe: role, installation, lancement, workflow, cas particuliers;
+- moins de tableaux, plus de listes simples;
+- etapes reformulees pour mieux suivre le chemin normal d'utilisation;
+- sections variables, enrichissement JSON et transmission rendues plus lisibles.
+
+Je n'ai pas lance de test applicatif, c'est uniquement une modification de documentation.
+
+## Echange 2 - Les trames ajoutees doivent apparaitre dans le JSON fusionne
+
+### Utilisateur
+
+> quand je rajoute une trame, quand je veux modifier un json existant il faut qu'elle apparaisse dans le json
+
+### Codex
+
+> Je vais regarder le flux "JSON existant / enrichissement / ajout de trame" dans `app.py` et le module builder, puis je corrige l'endroit ou la trame ajoutee se perd au moment de generer le JSON fusionne.
+
+Actions faites:
+
+- recherche des termes lies a la fusion et aux trames;
+- lecture de `app.py`;
+- lecture de `easy_codec_builder/core.py`;
+- identification des fonctions `build_json`, `merge_easy_codec_json` et `merge_cfg_block`.
+
+### Codex
+
+> J'ai trouve les zones utiles: `build_json()` construit les trames, puis `merge_easy_codec_json()` fusionne avec l'existant. Je vais lire ces deux morceaux en detail avec la partie UI qui choisit le mode maintenance.
+
+### Codex
+
+> Le risque principal semble etre la deduplication: la fusion considere parfois qu'une trame "existe deja" si sa signature ressemble trop, surtout avec des variables/placeholders. Je verifie aussi le cas ou tu charges directement un JSON a ajouter, pour ne pas casser ce workflow.
+
+### Codex
+
+> Je vais faire une correction plutot prudente: pendant la fusion, on ne doit pas jeter une trame ajoutee juste parce que la partie hexadecimale ressemble deja a une entree existante. La comparaison va tenir compte de la ligne complete `cfg_block` pour que deux trames avec un commentaire/usage different restent visibles.
+
+Modification faite dans `easy_codec_builder/core.py`:
+
+```python
+def cfg_block_item_signature(item):
+    if not isinstance(item, list) or not item:
+        return ""
+    frame_signature = cfg_frame_signature(item[0])
+    comment_signature = item[1] if len(item) > 1 and isinstance(item[1], str) else ""
+    return f"{frame_signature}|{comment_signature}"
+```
+
+Puis `merge_cfg_block` utilise cette signature complete au lieu de comparer seulement la trame.
+
+### Codex
+
+> La correction est posee dans la fusion des `cfg_block`. Je lance maintenant une verification Python, puis un mini-test de fusion pour confirmer qu'une trame avec un commentaire different est bien conservee dans le JSON final.
+
+Verifications faites:
+
+```bat
+python -m py_compile app.py app2.py easy_codec_builder\core.py
+```
+
+Mini-test de fusion:
+
+```python
+from easy_codec_builder.core import merge_easy_codec_json
+
+existing = {
+    "standard_params": {
+        "cfg_block": [["11 06 0402", "@oldComment"]]
+    }
+}
+generated = {
+    "standard_params": {
+        "cfg_block": [["11 06 0402", "@newComment"]]
+    }
+}
+
+merged, stats = merge_easy_codec_json(existing, generated)
+```
+
+Resultat utile:
+
+```text
+[['11 06 0402', '@oldComment'], ['11 06 0402', '@newComment']]
+```
+
+### Codex
+
+> La compilation passe, et le test de fusion montre bien que la trame ajoutee reste dans `cfg_block` au lieu d'etre comptee comme deja presente. Je verifie le diff final pour te resumer proprement.
+
+### Codex - reponse finale
+
+C'est corrige dans `easy_codec_builder/core.py`.
+
+Avant, pendant la fusion avec un JSON existant, l'outil pouvait considerer qu'une trame etait "deja presente" en regardant surtout la trame elle-meme. Maintenant il compare l'entree complete du `cfg_block`, donc une trame ajoutee avec un commentaire/usage different est bien gardee dans le JSON fusionne.
+
+Verifie avec:
+
+```bat
+python -m py_compile app.py app2.py easy_codec_builder\core.py
+```
+
+Et un mini-test de fusion confirme que la nouvelle trame est ajoutee au `cfg_block`.
+
+## Echange 3 - Question sur l'export des chats
+
+### Utilisateur
+
+> est ce qu'il y apossibilite d'exporte les chats a propos de cet outil ?
+
+### Codex - reponse finale
+
+Oui, il y a plusieurs facons selon ce que tu veux dire par "les chats".
+
+Si tu parles des conversations avec moi/Codex dans l'IDE: je ne peux pas exporter automatiquement l'historique complet depuis ici, mais tu peux generalement copier la conversation depuis l'interface, ou utiliser les fonctions d'export si ton outil/IDE les propose. Je peux aussi te preparer un fichier local de resume propre, par exemple `HISTORIQUE_OUTIL.md`, avec les decisions et modifications faites sur cet outil.
+
+Si tu parles des echanges utiles autour du projet: oui, on peut en faire une doc exportable dans le repo, par exemple:
+
+- `CHANGELOG.md` pour les modifications;
+- `NOTES_DEVELOPPEMENT.md` pour les discussions techniques;
+- `HISTORIQUE_ASSISTANT.md` pour resumer les demandes et reponses importantes;
+- une section dans le README.
+
+Pour ce projet, je te conseillerais plutot `NOTES_DEVELOPPEMENT.md`: simple, lisible, et ca evite de garder tout le chat brut.
+
+## Echange 4 - Premiere demande de fichier avec les echanges
+
+### Utilisateur
+
+> tu peux faire un fichier avec tous les echanges ?
+
+### Codex
+
+> Oui, je vais te creer un fichier Markdown dans le repo avec les echanges importants de cette conversation: demandes, reponses, actions faites et verifications. Je vais le garder lisible plutot qu'un gros bloc brut difficile a relire.
+
+Action faite:
+
+- creation de `HISTORIQUE_ECHANGES_OUTIL.md`.
+
+### Codex
+
+> Le fichier est cree. Je fais juste une lecture rapide et un `git status` pour verifier qu'il est bien la et que rien d'inattendu n'a bouge.
+
+### Codex
+
+> Le fichier est bien present. Petite chose a signaler: `git status` indique aussi `MODE_EMPLOI_ROM_CONFIG_FINDER.md` comme supprime, alors que je ne l'ai pas touche dans cette action; je vais verifier juste s'il existe encore sur disque ou si c'est un changement deja present cote workspace.
+
+Verification:
+
+- `MODE_EMPLOI_ROM_CONFIG_FINDER.md` n'etait plus present sur disque;
+- seul `MODE_EMPLOI_OUTIL_PRINCIPAL.md` apparaissait dans les fichiers `MODE_EMPLOI*`.
+
+### Codex - reponse finale
+
+J'ai cree le fichier `HISTORIQUE_ECHANGES_OUTIL.md`.
+
+Il contient:
+
+- les demandes que tu m'as faites;
+- les actions realisees;
+- les fichiers modifies;
+- la correction sur les trames ajoutees dans un JSON existant;
+- les verifications faites.
+
+A noter: `git status` indique aussi que `MODE_EMPLOI_ROM_CONFIG_FINDER.md` est supprime du dossier. Je ne l'ai pas supprime pendant cette action, donc c'est probablement un changement deja present dans le workspace ou fait ailleurs.
+
+## Echange 5 - Demande de contexte pour un autre developpeur
+
+### Utilisateur
+
+> non je ne veux pas ca ce que je veux c'est que tu fasses un truc pour que en quelque sorte, si un autre developpeur veut travailler dessus il puisse avoir acces a toute la mise en situation qu'on a fait comme ca il a pas besoin de tout redire
+
+### Codex
+
+> Ah oui, je vois mieux: tu veux un fichier de passation, pas un journal de chat. Je vais remplacer l'idee "historique des echanges" par un document de contexte developpeur: pourquoi l'outil existe, comment il marche, ce qu'on a deja decide, les pieges connus, et ou regarder dans le code.
+
+Actions faites:
+
+- lecture de `HISTORIQUE_ECHANGES_OUTIL.md`;
+- lecture de zones utiles dans `app.py`;
+- lecture de la partie fusion dans `easy_codec_builder/core.py`.
+
+### Codex
+
+> Je vais faire ca sous forme d'un vrai fichier de passation, avec un nom explicite. Je vais donc remplacer le fichier d'historique par `CONTEXTE_DEVELOPPEUR_OUTIL.md`, qui sera beaucoup plus utile pour un autre dev.
+
+Action faite:
+
+- suppression de `HISTORIQUE_ECHANGES_OUTIL.md`;
+- creation de `CONTEXTE_DEVELOPPEUR_OUTIL.md`.
+
+### Codex
+
+> Le fichier de passation est en place, avec le contexte utile au lieu du detail conversationnel. Je verifie maintenant son contenu et l'etat Git pour reperer s'il faut ajuster un nom ou une reference.
+
+### Codex - reponse finale
+
+Oui, la c'est beaucoup plus le bon format.
+
+J'ai remplace l'ancien fichier d'historique par `CONTEXTE_DEVELOPPEUR_OUTIL.md`. Il sert de fichier de passation pour un autre developpeur, avec:
+
+- le but du projet;
+- le workflow utilisateur;
+- les fichiers importants;
+- le role de `app.py` et `app2.py`;
+- les decisions deja prises;
+- les points sensibles comme la fusion `cfg_block`;
+- les verifications a faire avant de modifier.
+
+J'ai supprime `HISTORIQUE_ECHANGES_OUTIL.md`, parce qu'il ne correspondait pas a ce que tu voulais.
+
+A noter encore: `MODE_EMPLOI_ROM_CONFIG_FINDER.md` apparait supprime dans `git status`, mais ce n'est pas lie a cette modification.
+
+## Echange 6 - Demande d'export complet de la conversation
+
+### Utilisateur
+
+> je veux aussi avoir tout les chat enfin exporter toute nos conversation
+
+### Codex
+
+> D'accord, cette fois je garde les deux: le fichier de passation pour un dev, et un vrai export de conversation. Je vais creer un fichier separe avec le transcript lisible de nos echanges, sans remplacer le contexte developpeur.
+
+Action faite:
+
+- creation de ce fichier:
+
+```text
+EXPORT_CONVERSATION_CODEX_OUTIL.md
+```
+
+## Fichiers issus de ces echanges
+
+Fichier de passation pour un autre developpeur:
+
+```text
+CONTEXTE_DEVELOPPEUR_OUTIL.md
+```
+
+Fichier d'export de conversation:
+
+```text
+EXPORT_CONVERSATION_CODEX_OUTIL.md
+```
+
+Fichiers modifies pendant les echanges:
+
+```text
+MODE_EMPLOI_OUTIL_PRINCIPAL.md
+easy_codec_builder/core.py
+```
+
+Point a verifier dans le workspace:
+
+```text
+MODE_EMPLOI_ROM_CONFIG_FINDER.md
+```
+
+Ce fichier apparaissait comme supprime dans `git status`, mais cette suppression n'a pas ete faite volontairement par Codex pendant la creation du contexte developpeur ou de l'export de conversation.
+
+## Echange 7 - Garder tous les chats dans l'export
+
+### Utilisateur
+
+> je veux tous les chats dans le export conversation a moins qu'il y ait un moyen simple d'exporter tout ca
+
+### Codex
+
+> Je vais regarder la structure des fichiers d'export et ce que contient deja `EXPORT_CONVERSATION_CODEX_OUTIL.md`, puis je te dirai si on peut automatiser proprement ou s'il faut consolider depuis les fichiers existants.
+
+Constat:
+
+- `EXPORT_CONVERSATION_CODEX_OUTIL.md` est le bon fichier pour garder l'export lisible des chats autour de l'outil;
+- `HISTORIQUE_ECHANGES_OUTIL.md` et `MODE_EMPLOI_ROM_CONFIG_FINDER.md` etaient ouverts dans l'IDE, mais n'existaient plus sur disque dans le dossier du projet;
+- aucun dossier local `.codex` exploitable n'etait present dans le projet pour recuperer automatiquement un historique complet;
+- depuis cette session, Codex peut ajouter les messages visibles au fichier, mais ne peut pas garantir l'export automatique de toutes les anciennes conversations si elles ne sont pas accessibles dans le contexte ou dans un fichier local.
+
+Decision:
+
+- continuer a utiliser `EXPORT_CONVERSATION_CODEX_OUTIL.md` comme export principal des conversations visibles;
+- garder `CONTEXTE_DEVELOPPEUR_OUTIL.md` comme fichier de passation synthetique pour un autre developpeur;
+- si l'IDE ou l'outil Codex propose une fonction native d'export/copie de conversation, c'est le moyen le plus simple pour obtenir le transcript vraiment complet;
+- sinon, coller ici les morceaux manquants ou les exporter manuellement, puis Codex pourra les remettre au propre dans ce fichier.


### PR DESCRIPTION
## Summary

- Add `EXPORT_CONVERSATION_CODEX_OUTIL.md`.
- Document useful Codex exchanges around the Easy Codec tooling work.
- Preserve context, decisions, fixes, and validation steps for future reference.

